### PR TITLE
Fixed so version bump resets following

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 			if err != nil {
 				panic(fmt.Sprintf("parse version %q: %s", to, err))
 			}
-			return toVer.Add(addVer).String()
+			return toVer.Bump(addVer).String()
 		},
 		"sanitizePath": func(path string) string {
 			path = strings.ToLower(path)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -73,11 +73,21 @@ func (v Version) String() string {
 	return string(buf)
 }
 
-func (v Version) Add(other Version) Version {
+func (v Version) Bump(other Version) Version {
 	max := typ.Max(len(v.Segments), len(other.Segments))
 	segments := make([]uint, max)
+	var resetFollowing bool
 	for i := 0; i < max; i++ {
-		segments[i] = indexOrZero(v.Segments, i) + indexOrZero(other.Segments, i)
+		add := indexOrZero(other.Segments, i)
+		switch {
+		case resetFollowing:
+			segments[i] = add
+		case add > 0:
+			resetFollowing = true
+			fallthrough
+		default:
+			segments[i] = indexOrZero(v.Segments, i) + add
+		}
 	}
 	return Version{
 		Prefix:   other.Prefix,

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -101,7 +101,7 @@ func TestParse_errors(t *testing.T) {
 	}
 }
 
-func TestAdd(t *testing.T) {
+func TestBump(t *testing.T) {
 	tests := []struct {
 		name string
 		a    string
@@ -109,16 +109,34 @@ func TestAdd(t *testing.T) {
 		want string
 	}{
 		{
-			name: "add many",
-			a:    "1",
-			b:    "1.2.3.4",
-			want: "2.2.3.4",
+			name: "bump",
+			a:    "1.2.3",
+			b:    "0.0.1",
+			want: "1.2.4",
 		},
 		{
-			name: "add to many",
+			name: "adds segments",
+			a:    "1",
+			b:    "0.0.0.0",
+			want: "1.0.0.0",
+		},
+		{
+			name: "keeps segments",
 			a:    "1.2.3.4",
-			b:    "1",
-			want: "2.2.3.4",
+			b:    "0",
+			want: "1.2.3.4",
+		},
+		{
+			name: "resets following segments",
+			a:    "1.2.3.4",
+			b:    "0.1.0.0",
+			want: "1.3.0.0",
+		},
+		{
+			name: "resets and bumps following segments",
+			a:    "1.2.3.4",
+			b:    "0.1.1.1",
+			want: "1.3.1.1",
 		},
 		{
 			name: "add prefix",
@@ -168,7 +186,7 @@ func TestAdd(t *testing.T) {
 			if err != nil {
 				t.Errorf("parse %q: %s", tc.b, err)
 			}
-			result := aVer.Add(bVer)
+			result := aVer.Bump(bVer)
 			got := result.String()
 			if got != tc.want {
 				t.Errorf("want %q, got %q", tc.want, got)


### PR DESCRIPTION
E.g

```go
a, _ := version.Parse("v1.2.3")
b, _ := version.Parse("v0.1.0")
fmt.Println(a.Bump(b))
```

Old incorrect result: `v1.3.3`

New correct result: `v1.3.0`
