### PR TITLE
Added CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Risk.Ident GmbH <contact@riskident.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+* @RiskIdent/platform


### PR DESCRIPTION
Automatically assigns @RiskIdent/platform to reviews for this repo
