### PR TITLE
Add GitHub release action workflow using goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Fetch all tags
+        run: git fetch --force --tags
+      -
+        name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Risk.Ident GmbH <contact@riskident.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 name: goreleaser
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ go.work
 # NPM
 node_modules
 package-lock.json
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,8 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - darwin
+      - windows
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Risk.Ident GmbH <contact@riskident.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 before:
   hooks:
     - go mod tidy

--- a/README.md
+++ b/README.md
@@ -151,9 +151,19 @@ You can also persist build flags in a `.env` file, e.g:
 REGISTRY=docker.io/my-username
 ```
 
-## Deployment
+## Releasing
 
-**TODO**
+1. Create a new release on GitHub, with "v" prefix on version: <https://github.com/RiskIdent/jelease/releases/new>
+
+2. Write a small changelog, like so:
+
+   ```markdown
+   ## Changes (since v0.3.0)
+
+   - Added some feature. (#123)
+   ```
+
+3. Our GitHub Action with goreleaser will build and add artifacts to release
 
 ## Logo
 


### PR DESCRIPTION
This action will release a new version of jelease when we push a new tag starting with the letter **v** (`'v*'`)