### PR TITLE
[OP-2197] Update Go to fix GO-2023-2185

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/jelease
 
-go 1.21.3
+go 1.21.4
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0


### PR DESCRIPTION
OP-2197

Fixes: https://pkg.go.dev/vuln/GO-2023-2185
