### PR TITLE
Update Go to fix GO-2023-2182 and GO-2023-2185

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/jelease
 
-go 1.21.4
+go 1.21.5
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0


### PR DESCRIPTION
Govulncheck output:

```
Vulnerability #1: GO-2023-2382
    Denial of service via chunk extensions in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2382
  Standard library
    Found in: net/http/internal@go1.21.4
    Fixed in: net/http/internal@go1.21.5
    Example traces found:
Error:       #1: pkg/jira/jira.go:194:31: jira.client.StatusMustExist calls io.ReadAll, which eventually calls internal.chunkedReader.Read

Vulnerability #2: GO-2023-2185
    Insecure parsing of Windows paths with a \??\ prefix in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2185
  Standard library
    Found in: path/filepath@go1.21.4
    Fixed in: path/filepath@go1.21.5
    Platforms: windows
    Example traces found:
Error:       #1: pkg/git/cmd.go:194:27: git.runGitCmd calls exec.Cmd.Output, which eventually calls filepath.Abs
Error:       #2: cmd/root.go:83:24: cmd.Execute calls cobra.Command.Execute, which eventually calls filepath.Base
Error:       #3: cmd/root.go:106:21: cmd.configSetup calls viper.AddConfigPath, which eventually calls filepath.Clean
Error:       #4: pkg/patch/patch.go:59:23: patch.Apply calls filepath.Join
Error:       #5: cmd/root.go:85:19: cmd.Execute calls zerolog.Event.Msgf, which eventually calls filepath.Rel
Error:       #6: pkg/git/git.go:68:42: git.CloneTemp calls filepath.Split
Error:       #7: pkg/git/cmd.go:194:27: git.runGitCmd calls exec.Cmd.Output, which eventually calls filepath.VolumeName
Error:       #8: pkg/git/cmd.go:194:27: git.runGitCmd calls exec.Cmd.Output, which eventually calls filepath.Abs
Error:       #9: cmd/root.go:83:24: cmd.Execute calls cobra.Command.Execute, which eventually calls filepath.Base
Error:       #10: cmd/root.go:106:21: cmd.configSetup calls viper.AddConfigPath, which eventually calls filepath.Clean
Error:       #11: pkg/patch/patch.go:59:23: patch.Apply calls filepath.Join
Error:       #12: cmd/root.go:85:19: cmd.Execute calls zerolog.Event.Msgf, which eventually calls filepath.Rel
Error:       #13: pkg/git/git.go:68:42: git.CloneTemp calls filepath.Split
Error:       #14: pkg/git/cmd.go:194:27: git.runGitCmd calls exec.Cmd.Output, which eventually calls filepath.VolumeName
```

Source: https://github.com/RiskIdent/jelease/actions/runs/7164509344/job/19504712874

Fixed by updating Go.
