### PR TITLE
Add Docker image to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,25 +15,35 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Fetch all tags
+
+      - name: Fetch all tags
         run: git fetch --force --tags
-      -
-        name: Set up Go
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      -
-        name: Run GoReleaser
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,20 +11,16 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Fetch all tags
-        run: git fetch --force --tags
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -37,14 +33,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,7 @@ dockers:
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --build-arg=VERSION={{ .Version }}
 
   - image_templates:
       - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-arm64v8"
@@ -41,6 +42,7 @@ dockers:
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --build-arg=VERSION={{ .Version }}
 
 docker_manifests:
   - name_template: "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,7 @@
 before:
   hooks:
     - go mod tidy
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -12,6 +13,44 @@ builds:
       - linux
       - darwin
       - windows
+    goarch:
+      - amd64
+      - arm64
+
+dockers:
+  - image_templates:
+      - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    goarch: arm64
+    goos: linux
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+
+  - image_templates:
+      - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+    dockerfile: Dockerfile
+    use: buildx
+    goarch: arm64
+    goos: linux
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+
+docker_manifests:
+  - name_template: "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+  - name_template: "ghcr.io/riskident/{{ .ProjectName }}:latest"
+    image_templates:
+      - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "ghcr.io/riskident/{{ .ProjectName }}:{{ .Version }}-arm64v8"
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
Automatically build and push (multi-arch) Docker images to ghcr: <https://github.com/RiskIdent/jelease/pkgs/container/jelease>

I followed this blog post: <https://carlosbecker.com/posts/multi-platform-docker-images-goreleaser-gh-actions/>, but changed some stuff to make sure it's up-to-date.
