### PR TITLE
Updated to Go 1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-FROM docker.io/library/golang:1.22.4-alpine AS build
+FROM docker.io/library/golang:1.22.5-alpine AS build
 WORKDIR /jelease
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/RiskIdent/jelease
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/a-h/templ v0.2.731


### PR DESCRIPTION
govulncheck reports vulnerability:

```
Vulnerability #1: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5
    Example traces found:
       #1: pkg/newreleases/newreleases.go:258:35: newreleases.NewReleases.ApplyLocalConfig calls newreleases.ProjectsService.Add, which eventually calls http.Client.Do
       #2: pkg/github/appsclient.go:89:36: github.appsClient.GitCredentialsForRepo calls ghinstallation.Transport.Token, which eventually calls http.Transport.RoundTrip
```

The fix is to update Go to v1.22.5
