### PR TITLE
Update goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         if: "!startsWith(github.ref, 'refs/tags/')"
         with:
-          version: latest
+          version: "~> 2"
           args: release --clean --skip=publish --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -55,7 +57,7 @@ docker_manifests:
       - "ghcr.io/riskident/{{ .ProjectName }}:v{{ .Version }}-arm64v8"
 
 archives:
-  - format: tar.gz
+  - formats: [ tar.gz ]
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -67,7 +69,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
The latest release pipeline worked, but had some warnings: https://github.com/RiskIdent/jelease/actions/runs/13386379390/job/37383975215

This PR fixes those warnings
